### PR TITLE
build: enhance security by restricting GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,6 +19,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    
+# Sets permissions for the jobs according to PoLP
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
 # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Limiting GITHUB_TOKEN permissions in GitHub Actions workflow according to the principle of least privillege.