### PR TITLE
26 new task button not working on standards page

### DIFF
--- a/src/main/resources/templates/standards/supporting.html
+++ b/src/main/resources/templates/standards/supporting.html
@@ -45,10 +45,9 @@
     <nav th:replace="~{fragments/navbar :: main (page='standarder')}"></nav>
 </div>
 
-<div th:replace="~{fragments/footer :: taskDialog}"></div>
 <script type="text/javascript" th:src="@{/js/standards/supporting.js}" defer></script>
 <div th:replace="~{fragments/footer :: scripts}"></div>
-
+<div th:replace="~{fragments/footer :: taskDialog}"></div>
 
 <script th:inline="javascript">
     /*<![CDATA[*/

--- a/src/main/resources/templates/standards/supporting_view.html
+++ b/src/main/resources/templates/standards/supporting_view.html
@@ -164,6 +164,7 @@
 <script type="text/javascript" th:src="@{/js/standards/supporting.js}" defer></script>
 <script type="text/javascript" th:src="@{/js/ckeditor/ckeditor.js}" defer></script>
 <div th:replace="~{fragments/footer :: scripts}"></div>
+<div th:replace="~{fragments/footer :: taskDialog}"></div>
 
 <script th:inline="javascript">
     /*<![CDATA[*/


### PR DESCRIPTION
Fixed the 'New task' buttons for the standard sub pages.

Standard/Supporting/{id} won't work till all the choices.js calls have finished processing. 
Created a new task to fix the choices.js calls delaying the page.